### PR TITLE
update CMakeLists.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Usage:
  * See `examples` directory
  
 # Remarks
-This code has been tested with an OpenCASCADE 7.4.0 prebuilt binary (`opencascade-7.4.0-vc14-64.exe`). With changes in the configuration section in the `CMakeLists.txt` file the build should also work with other OpenCASCADE versions. For building on Linux the `CMakeLists.txt` file needs further adaptions.
+This code has been tested with an OpenCASCADE 7.4.0 prebuilt binary (`opencascade-7.4.0-vc14-64.exe`) on Windows, as well as OpenCASCADE system packages on openSUSE Linux. With changes in the configuration section in the `CMakeLists.txt` file the build should also work with other OpenCASCADE versions.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,19 +65,37 @@ endif()
 if(OpenCASCADE_WITH_FREEIMAGE)
 	set(FREEIMAGE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/lib" CACHE PATH "FreeImage library directory")
 	set(FREEIMAGE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/bin" CACHE PATH "FreeImage binary directory")
+	option(FREEIMAGE_SHARED "link FreeImage as shared library" ON)
 endif()
 if(OpenCASCADE_WITH_FFMPEG)
 	set(FFMPEG_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/lib" CACHE PATH "FFmpeg library directory")
 	set(FFMPEG_BIN_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/bin" CACHE PATH "FFmpeg binary directory")
+	option(FFMPEG_SHARED "link FFmpeg as shared libraries" ON)
 endif()
 if(OpenCASCADE_WITH_FREETYPE)
 	set(FREETYPE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/lib" CACHE PATH "FreeType library directory")
 	set(FREETYPE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/bin" CACHE PATH "FreeType binary directory")
+	option(FREETYPE_SHARED "link FreeType as shared library" ON)
 endif()
 
 include_directories(${OpenCASCADE_INCLUDE_DIR} ${OCE_INCLUDE_DIRS})
 
-set(LIBS TKernel TKMath TKBRep TKLCAF TKXDESTEP TKSTL)
+if(NOT OpenCASCADE_BUILD_SHARED_LIBS)
+	if(OpenCASCADE_WITH_TBB)
+		link_directories(${TBB_LIBRARY_PREFIX})
+	endif()
+	if(OpenCASCADE_WITH_FREEIMAGE)
+		link_directories(${FREEIMAGE_LIBRARY_PREFIX})
+	endif()
+	if(OpenCASCADE_WITH_FFMPEG)
+		link_directories(${FFMPEG_LIBRARY_PREFIX})
+	endif()
+	if(OpenCASCADE_WITH_FREETYPE)
+		link_directories(${FREETYPE_LIBRARY_PREFIX})
+	endif()
+endif()
+
+set(LIBS TKernel TKMath TKBRep TKLCAF TKXDESTEP TKXCAF TKMesh TKTopAlgo TKSTL TKG3d TKG2d TKGeomBase TKCDF TKXSBase TKSTEP TKSTEPBase TKSTEPAttr TKShHealing TKVCAF TKCAF TKService TKV3d TKGeomAlgo TKSTEP209 TKBO TKHLR)
 
 if(WIN32)
 	#
@@ -118,28 +136,30 @@ endif()
 
 if(INSTALL_DEPENDENCIES)
 	if(WIN32)
-		foreach(LIB ${LIBS} TKXCAF TKMesh TKTopAlgo TKSTEP TKSTEPAttr TKSTEPBase TKXSBase TKShHealing TKG3d TKSTEP209 TKVCAF TKV3d TKService TKCAF TKCDF TKGeomBase TKHLR TKBO TKPrim TKGeomAlgo TKG2d)
-			# installing imported targets as TARGETS is not possible (see https://gitlab.kitware.com/cmake/cmake/-/issues/14311)
-			# so we must use FILES mode
-			install(FILES $<TARGET_FILE:${LIB}> TYPE BIN)
-		endforeach()
+		if(OpenCASCADE_BUILD_SHARED_LIBS)
+			foreach(LIB ${LIBS} TKPrim)
+				# installing imported targets as TARGETS is not possible (see https://gitlab.kitware.com/cmake/cmake/-/issues/14311)
+				# so we must use FILES mode
+				install(FILES $<TARGET_FILE:${LIB}> TYPE BIN)
+			endforeach()
+		endif()
 		if(OpenCASCADE_WITH_TBB)
 			install(FILES 
 				"${TBB_BIN_PREFIX}/tbb.dll"
 				"${TBB_BIN_PREFIX}/tbbmalloc.dll"
 				TYPE BIN)
 		endif()
-		if(OpenCASCADE_WITH_FREEIMAGE)
+		if(OpenCASCADE_WITH_FREEIMAGE AND FREEIMAGE_SHARED)
 			install(FILES 
 				"${FREEIMAGE_BIN_PREFIX}/FreeImage.dll"
 				TYPE BIN)
 		endif()
-		if(OpenCASCADE_WITH_FREETYPE)
+		if(OpenCASCADE_WITH_FREETYPE AND FREETYPE_SHARED)
 			install(FILES 
 				"${FREETYPE_BIN_PREFIX}/freetype.dll"
 				TYPE BIN)
 		endif()
-		if(OpenCASCADE_WITH_FFMPEG)
+		if(OpenCASCADE_WITH_FFMPEG AND FFMPEG_SHARED)
 			install(FILES 
 				"${FFMPEG_BIN_PREFIX}/avcodec-57.dll"
 				"${FFMPEG_BIN_PREFIX}/avformat-57.dll"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,8 @@ endif()
 
 set(CMAKE_PREFIX_PATH "${OPENCASCADE_PREFIX};${CMAKE_PREFIX_PATH}")
 
-find_package(OpenCASCADE REQUIRED)
+find_package(OpenCASCADE)
+find_package(OCE)
 
 if(OpenCASCADE_WITH_TBB)
 	set(TBB_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/tbb_2017.0.100/lib/intel64/vc14" CACHE PATH "TBB library directory")
@@ -74,7 +75,7 @@ if(OpenCASCADE_WITH_FREETYPE)
 	set(FREETYPE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/bin" CACHE PATH "FreeType binary directory")
 endif()
 
-include_directories(${OpenCASCADE_INCLUDE_DIR})
+include_directories(${OpenCASCADE_INCLUDE_DIR} ${OCE_INCLUDE_DIRS})
 
 set(LIBS TKernel TKMath TKBRep TKLCAF TKXDESTEP TKSTL)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 include_directories(${OpenCASCADE_INCLUDE_DIR})
 
-set(LIBS TKernel TKMath TKGeomBase TKTopAlgo TKMesh TKSTEP TKCAF TKXCAF TKSTEPAttr TKSTEP209 TKSTEPBase TKXSBase TKLCAF TKVCAF TKCDF TKBO TKShHealing TKPrim TKGeomAlgo TKBRep TKG2d TKG3d TKService TKV3d TKXDESTEP TKSTL)
+set(LIBS TKernel TKMath TKBRep TKLCAF TKXDESTEP TKSTL)
 
 if(WIN32)
 	#
@@ -117,7 +117,7 @@ endif()
 
 if(INSTALL_DEPENDENCIES)
 	if(WIN32)
-		foreach(LIB ${LIBS} TKHLR)
+		foreach(LIB ${LIBS} TKXCAF TKMesh TKTopAlgo TKSTEP TKSTEPAttr TKSTEPBase TKXSBase TKShHealing TKG3d TKSTEP209 TKVCAF TKV3d TKService TKCAF TKCDF TKGeomBase TKHLR TKBO TKPrim TKGeomAlgo TKG2d)
 			# installing imported targets as TARGETS is not possible (see https://gitlab.kitware.com/cmake/cmake/-/issues/14311)
 			# so we must use FILES mode
 			install(FILES $<TARGET_FILE:${LIB}> TYPE BIN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,80 +45,106 @@ project (STEPToMesh)
 # begin of configuration section
 # change values according to path structure in OpenCASCADE installation
 #
-set(OPENCASCADE_PREFIX "C:/OpenCASCADE-7.4.0-vc14-64")
-set(OPENCASCADE_BIN_PREFIX "${OPENCASCADE_PREFIX}/opencascade-7.4.0/win64/vc14/bin")
-set(TBB_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/tbb_2017.0.100/lib/intel64/vc14")
-set(TBB_BIN_PREFIX "${OPENCASCADE_PREFIX}/tbb_2017.0.100/bin/intel64/vc14")
-set(FREEIMAGE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/lib")
-set(FREEIMAGE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/bin")
-set(FFMPEG_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/lib")
-set(FFMPEG_BIN_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/bin")
-set(FREETYPE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/lib")
-set(FREETYPE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/bin")
+set(OPENCASCADE_PREFIX "C:/OpenCASCADE-7.4.0-vc14-64" CACHE PATH "OpenCASCADE prefix")
+if(WIN32)
+	set(CMAKE_INSTALL_BINDIR "." CACHE PATH "User executables (bin)")
+endif()
 #
 # end of configuration section
 #
 
 set(CMAKE_PREFIX_PATH "${OPENCASCADE_PREFIX};${CMAKE_PREFIX_PATH}")
 
-find_package(OpenCASCADE)
+find_package(OpenCASCADE REQUIRED)
+
+if(OpenCASCADE_WITH_TBB)
+	set(TBB_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/tbb_2017.0.100/lib/intel64/vc14" CACHE PATH "TBB library directory")
+	set(TBB_BIN_PREFIX "${OPENCASCADE_PREFIX}/tbb_2017.0.100/bin/intel64/vc14" CACHE PATH "TBB binary directory")
+endif()
+if(OpenCASCADE_WITH_FREEIMAGE)
+	set(FREEIMAGE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/lib" CACHE PATH "FreeImage library directory")
+	set(FREEIMAGE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freeimage-3.17.0-vc14-64/bin" CACHE PATH "FreeImage binary directory")
+endif()
+if(OpenCASCADE_WITH_FFMPEG)
+	set(FFMPEG_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/lib" CACHE PATH "FFmpeg library directory")
+	set(FFMPEG_BIN_PREFIX "${OPENCASCADE_PREFIX}/ffmpeg-3.3.4-64/bin" CACHE PATH "FFmpeg binary directory")
+endif()
+if(OpenCASCADE_WITH_FREETYPE)
+	set(FREETYPE_LIBRARY_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/lib" CACHE PATH "FreeType library directory")
+	set(FREETYPE_BIN_PREFIX "${OPENCASCADE_PREFIX}/freetype-2.5.5-vc14-64/bin" CACHE PATH "FreeType binary directory")
+endif()
 
 include_directories(${OpenCASCADE_INCLUDE_DIR})
 
 set(LIBS TKernel TKMath TKGeomBase TKTopAlgo TKMesh TKSTEP TKCAF TKXCAF TKSTEPAttr TKSTEP209 TKSTEPBase TKXSBase TKLCAF TKVCAF TKCDF TKBO TKShHealing TKPrim TKGeomAlgo TKBRep TKG2d TKG3d TKService TKV3d TKXDESTEP TKSTL)
 
-#
-# update libraries for imported OpenCASCADE targets (modules),
-# because they have predefined paths from OpenCASCADE build
-#
-update_target_library("${LIBS}" "^.+/tbbmalloc\\\\.lib$" "${TBB_LIBRARY_PREFIX}/tbbmalloc.lib")
-update_target_library("${LIBS}" "^.+/tbb\\\\.lib$" "${TBB_LIBRARY_PREFIX}/tbb.lib")
-update_target_library("${LIBS}" "^.+/FreeImage\\\\.lib$" "${FREEIMAGE_LIBRARY_PREFIX}/FreeImage.lib")
-update_target_library("${LIBS}" "^.+/avcodec\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avcodec.lib")
-update_target_library("${LIBS}" "^.+/avformat\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avformat.lib")
-update_target_library("${LIBS}" "^.+/swscale\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/swscale.lib")
-update_target_library("${LIBS}" "^.+/avutil\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avutil.lib")
-update_target_library("${LIBS}" "^.+/freetype\\\\.lib$" "${FREETYPE_LIBRARY_PREFIX}/freetype.lib")
+if(WIN32)
+	#
+	# update libraries for imported OpenCASCADE targets (modules),
+	# because they have predefined paths from OpenCASCADE build
+	#
+	if(OpenCASCADE_WITH_TBB)
+		update_target_library("${LIBS}" "^.+/tbbmalloc\\\\.lib$" "${TBB_LIBRARY_PREFIX}/tbbmalloc.lib")
+		update_target_library("${LIBS}" "^.+/tbb\\\\.lib$" "${TBB_LIBRARY_PREFIX}/tbb.lib")
+	endif()
+	if(OpenCASCADE_WITH_FREEIMAGE)
+		update_target_library("${LIBS}" "^.+/FreeImage\\\\.lib$" "${FREEIMAGE_LIBRARY_PREFIX}/FreeImage.lib")
+	endif()
+	if(OpenCASCADE_WITH_FFMPEG)
+		update_target_library("${LIBS}" "^.+/avcodec\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avcodec.lib")
+		update_target_library("${LIBS}" "^.+/avformat\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avformat.lib")
+		update_target_library("${LIBS}" "^.+/swscale\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/swscale.lib")
+		update_target_library("${LIBS}" "^.+/avutil\\\\.lib$" "${FFMPEG_LIBRARY_PREFIX}/avutil.lib")
+	endif()
+	if(OpenCASCADE_WITH_FREETYPE)
+		update_target_library("${LIBS}" "^.+/freetype\\\\.lib$" "${FREETYPE_LIBRARY_PREFIX}/freetype.lib")
+	endif()
+endif()
 
 add_executable(STEPToMesh STEPToMesh.cpp)
 
 target_link_libraries(STEPToMesh ${LIBS})
 
-add_custom_command(TARGET STEPToMesh POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy_if_different
-	"${OPENCASCADE_BIN_PREFIX}/TKBRep.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKernel.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKG2d.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKG3d.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKGeomAlgo.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKGeomBase.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKMath.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKMesh.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKShHealing.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKSTEP.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKSTEP209.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKSTEPAttr.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKSTEPBase.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKTopAlgo.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKXSBase.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKXDESTEP.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKXCAF.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKLCAF.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKVCAF.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKV3d.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKCAF.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKCDF.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKBO.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKService.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKHLR.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKPrim.dll"
-	"${OPENCASCADE_BIN_PREFIX}/TKSTL.dll"
-	"${TBB_BIN_PREFIX}/tbb.dll"
-	"${TBB_BIN_PREFIX}/tbbmalloc.dll"
-	"${FREEIMAGE_BIN_PREFIX}/FreeImage.dll"
-	"${FREETYPE_BIN_PREFIX}/freetype.dll"
-	"${FFMPEG_BIN_PREFIX}/avcodec-57.dll"
-	"${FFMPEG_BIN_PREFIX}/avformat-57.dll"
-	"${FFMPEG_BIN_PREFIX}/swscale-4.dll"
-	"${FFMPEG_BIN_PREFIX}/avutil-55.dll"
-	$<TARGET_FILE_DIR:STEPToMesh>)
+include(GNUInstallDirs)
+
+install(TARGETS STEPToMesh)
+
+if(WIN32)
+	option(INSTALL_DEPENDENCIES "whether to install dependent libraries or not" ON)
+else()
+	option(INSTALL_DEPENDENCIES "whether to install dependent libraries or not" OFF)
+endif()
+
+if(INSTALL_DEPENDENCIES)
+	if(WIN32)
+		foreach(LIB ${LIBS} TKHLR)
+			# installing imported targets as TARGETS is not possible (see https://gitlab.kitware.com/cmake/cmake/-/issues/14311)
+			# so we must use FILES mode
+			install(FILES $<TARGET_FILE:${LIB}> TYPE BIN)
+		endforeach()
+		if(OpenCASCADE_WITH_TBB)
+			install(FILES 
+				"${TBB_BIN_PREFIX}/tbb.dll"
+				"${TBB_BIN_PREFIX}/tbbmalloc.dll"
+				TYPE BIN)
+		endif()
+		if(OpenCASCADE_WITH_FREEIMAGE)
+			install(FILES 
+				"${FREEIMAGE_BIN_PREFIX}/FreeImage.dll"
+				TYPE BIN)
+		endif()
+		if(OpenCASCADE_WITH_FREETYPE)
+			install(FILES 
+				"${FREETYPE_BIN_PREFIX}/freetype.dll"
+				TYPE BIN)
+		endif()
+		if(OpenCASCADE_WITH_FFMPEG)
+			install(FILES 
+				"${FFMPEG_BIN_PREFIX}/avcodec-57.dll"
+				"${FFMPEG_BIN_PREFIX}/avformat-57.dll"
+				"${FFMPEG_BIN_PREFIX}/swscale-4.dll"
+				"${FFMPEG_BIN_PREFIX}/avutil-55.dll"
+				TYPE BIN)
+		endif()
+	endif()
+endif()

--- a/src/STEPToMesh.cpp
+++ b/src/STEPToMesh.cpp
@@ -32,6 +32,7 @@
 #include <XCAFDoc_ShapeTool.hxx>
 #include <TDocStd_Document.hxx>
 #include <TDF_ChildIterator.hxx>
+#include <TDF_LabelSequence.hxx>
 #include <TDataStd_Name.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <BRepBuilderAPI_Transform.hxx>


### PR DESCRIPTION
 * make configuration settings cache variables to allow setting them externally, allowing to build against another version of OpenCascade easier
 * make the update_target_library hack conditional for Windows (other OSes usually have a package manager that takes care of installing the correct versions of libraries and doesn't need this)
 * make the adjustments for the optional OpenCascade dependencies conditional according to the actual used OpenCascase configuration
 * replace the ugly post-build hack to copy DLLs with an actual "installation" to "install" these (the DLLs conditionally for Windows as well and optional)