### PR TITLE
print exception messages on `cerr` instead of `cout`.

### DIFF
--- a/src/STEPToMesh.cpp
+++ b/src/STEPToMesh.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
 		return EXIT_SUCCESS;
 	}
 	catch (const std::exception& ex) {
-		std::cout << ex.what();
+		std::cerr << ex.what();
 		return EXIT_FAILURE;
 	}
 }


### PR DESCRIPTION
This allows to easier distinguish errors from legitimate output (from `-c`) programatically.

Note: this is untested because I am unable to build the main branch right now because I have the wrong version of OpenCASCADE and manually editing CMakeLists.txt is too tedious (see #1).